### PR TITLE
Suppress extended flag notation when default matches zero value

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/alecthomas/kong"
@@ -47,7 +48,11 @@ func Command(node *kong.Node) command.Command {
 			Required:    flag.Required,
 			Hidden:      flag.Hidden,
 			Description: flag.Help,
-			Default:     flag.Default,
+		}
+		if flag.HasDefault {
+			if z := zeroDefaultString(flag); z != flag.Default {
+				f.Default = flag.Default
+			}
 		}
 		if flag.Short != 0 {
 			f.Shorthand = string(flag.Short)
@@ -87,4 +92,11 @@ func Command(node *kong.Node) command.Command {
 		}
 	}
 	return cmd
+}
+
+func zeroDefaultString(flag *kong.Flag) string {
+	if !flag.Target.IsValid() {
+		return ""
+	}
+	return fmt.Sprintf("%v", reflect.Zero(flag.Target.Type()).Interface())
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -1,0 +1,58 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/alecthomas/kong"
+)
+
+type testCLI struct {
+	BoolWithDefault    bool `default:"true"`
+	BoolWithoutDefault bool
+	BoolZeroDefault    bool   `default:"false"`
+	IntWithDefault     int    `default:"42"`
+	IntZeroDefault     int    `default:"0"`
+	StringWithDefault  string `default:"hello"`
+	StringZeroDefault  string `default:""`
+}
+
+func TestZeroDefaultSuppressed(t *testing.T) {
+	k, err := kong.New(&testCLI{}, kong.NoDefaultHelp())
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+
+	cmd := Command(k.Model.Node)
+
+	tests := []struct {
+		flagName      string
+		shouldHaveDef bool
+	}{
+		{"bool-with-default", true},     // default:"true" != zero (false)
+		{"bool-without-default", false}, // no default tag
+		{"bool-zero-default", false},    // default:"false" == zero (false)
+		{"int-with-default", true},      // default:"42" != zero (0)
+		{"int-zero-default", false},     // default:"0" == zero (0)
+		{"string-with-default", true},   // default:"hello" != zero ("")
+		{"string-zero-default", false},  // default:"" == zero ("")
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.flagName, func(t *testing.T) {
+			key := "--" + tt.flagName
+			flag, ok := cmd.Flags[key]
+			if !ok {
+				key = "--" + tt.flagName + "="
+				flag, ok = cmd.Flags[key]
+			}
+			if !ok {
+				t.Fatalf("flag --%s not found in cmd.Flags", tt.flagName)
+			}
+			hasDef := flag.Default != ""
+			if hasDef != tt.shouldHaveDef {
+				t.Errorf("flag --%s: expected Default=%v, got Default=%q",
+					tt.flagName, tt.shouldHaveDef, flag.Default)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Only set the Default field on carapace-spec flags when the kong
default tag value differs from the Go type's zero value, avoiding
unnecessary extended YAML notation for cases like default:"false"
on bools or default:"0" on ints.

Assisted-by: Crush:glm-5.2
